### PR TITLE
SD-1240 SV Translations (#881)

### DIFF
--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -537,8 +537,8 @@ sv:
     adjustments: "Ändringar"
     adjustment_labels:
       tax_rates:
-        including_tax: "% {name}% {amount} (ingår i priset)"
-        excluding_tax: "% {name}% {amount}"
+        including_tax: '%{name}%{amount} (ingår i priset)'
+        excluding_tax: '%{name}%{amount}'
     admin:
       tab:
         configuration: Konfiguration
@@ -1233,7 +1233,7 @@ sv:
       resumed: Återupptagen
       returned: Returnerad
       payment_confirm: Betalningsbekräftan
-    order_summary: Order
+    order_summary: Ordersammanfattning
     order_success: Toppen!
     order_success_explain: Ordern mottagen!
     order_sure_want_to: "Är du säker på att du vill %{event} denna order?"
@@ -1289,7 +1289,7 @@ sv:
     percent_per_item: Procent per artikel
     permalink: Permalink
     phone: Telefon
-    place_order: Placera order
+    place_order: Beställa
     please_define_payment_methods: Definiera först någon betalningsmetod
     plp:
       clear_all: Rensa filter


### PR DESCRIPTION
* SD-1248

removing unnecessary space enable the translation of TAX within order summary

* SD-1247

Adding missing translation to Order Summary
Correcting Place Order translation

* Revert x in models